### PR TITLE
feat: add RAG pipeline, flashcard batch mode, and dual chat modes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ vault/
 
 # Claude Code
 .claude/worktrees/
+
+db/ 

--- a/backend/api/app.py
+++ b/backend/api/app.py
@@ -23,8 +23,21 @@ async def lifespan(app: FastAPI):
     import api.dependencies as deps
     from client.mcp_client import MCPClient
 
+    from services.rag import RagChain
+
     deps._mcp_client = MCPClient()
     await deps._mcp_client.__aenter__()
+
+    # RagChain loads FAISS from disk once; shared across all requests.
+    # If FAISS is unavailable (index not built yet), we log a warning and
+    # continue — MCP chat still works; RAG endpoints will return a 503.
+    try:
+        deps._rag_chain = RagChain(deps._model)
+        print("FAISS index loaded successfully.")
+    except Exception as exc:
+        print(f"WARNING: Could not load FAISS index — RAG features disabled. ({exc})")
+        deps._rag_chain = None
+
     try:
         yield
     finally:

--- a/backend/api/dependencies.py
+++ b/backend/api/dependencies.py
@@ -13,11 +13,13 @@ if TYPE_CHECKING:
     from client.mcp_client import MCPClient
     from config import Config
     from model.base import BaseModel
+    from services.rag import RagChain
 
 # Populated by api/app.py lifespan before the first request arrives
 _model: "BaseModel | None" = None
 _config: "Config | None" = None
 _mcp_client: "MCPClient | None" = None
+_rag_chain: "RagChain | None" = None
 
 
 def get_model() -> "BaseModel":
@@ -33,3 +35,21 @@ def get_config() -> "Config":
 def get_mcp_client() -> "MCPClient":
     assert _mcp_client is not None, "MCPClient not initialised"
     return _mcp_client
+
+
+def get_rag_chain() -> "RagChain":
+    """
+    Returns the shared RagChain singleton (loads FAISS once at startup).
+    Raises HTTP 503 if FAISS index was not loaded (index not built yet).
+    """
+    if _rag_chain is None:
+        from fastapi import HTTPException
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                "FAISS index is not available. "
+                "Run vectorization.py to build it first, "
+                "then set SAVE_INDEX_PATH in your .env file."
+            ),
+        )
+    return _rag_chain

--- a/backend/api/routes/chat.py
+++ b/backend/api/routes/chat.py
@@ -1,21 +1,27 @@
 """
 Chat routes:
-  WS  /ws          — streaming chat per browser session
-  GET /flashcard   — generate a Q&A flashcard from a random vault note
+  WS  /ws               — MCP chat: model calls Obsidian tools
+  WS  /ask              — RAG chat: answer based on FAISS search over chunks
+  GET /flashcard/batch  — RAG flashcards: batch of 3-6 questions on one topic
 """
 from __future__ import annotations
 
-from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+import logging
 
-from api.dependencies import get_config, get_mcp_client, get_model
-from services.orchestrator import Orchestrator, generate_flashcard
+from fastapi import APIRouter, HTTPException, WebSocket, WebSocketDisconnect
+
+from api.dependencies import get_config, get_mcp_client, get_model, get_rag_chain
+from services.orchestrator import Orchestrator
+from services.rag import generate_flashcard_batch
+
+log = logging.getLogger(__name__)
 
 router = APIRouter()
 
 
 @router.websocket("/ws")
 async def chat_ws(websocket: WebSocket) -> None:
-    """One WebSocket connection = one independent chat session."""
+    """One WebSocket connection = one independent MCP chat session."""
     await websocket.accept()
 
     model = get_model()
@@ -40,18 +46,70 @@ async def chat_ws(websocket: WebSocket) -> None:
             pass
 
 
-@router.get("/flashcard")
-async def get_flashcard(exclude: str = "") -> dict:
+@router.websocket("/ask")
+async def rag_ws(websocket: WebSocket) -> None:
     """
-    Return a Q&A flashcard generated from a randomly chosen vault note.
+    RAG chat: each question → FAISS search → Gemini → answer.
+
+    Message format matches /ws for frontend compatibility:
+      Client → {"message": "question"}
+      Server → {"type": "done", "content": "answer", "sources": [...]}
+               {"type": "error", "content": "error text"}
+    """
+    await websocket.accept()
+
+    rag = get_rag_chain()  # singleton — FAISS already loaded
+
+    try:
+        while True:
+            data = await websocket.receive_json()
+            message = data.get("message", "").strip()
+            if not message:
+                continue
+
+            try:
+                result = await rag.ask(message)
+                await websocket.send_json({
+                    "type": "done",
+                    "content": result.answer,
+                    "sources": result.sources,
+                })
+            except Exception as exc:
+                await websocket.send_json({"type": "error", "content": str(exc)})
+
+    except WebSocketDisconnect:
+        pass
+
+
+@router.get("/flashcard/batch")
+async def get_flashcard_batch(exclude_topics: str = "") -> dict:
+    """
+    Generates a batch of 3-6 flashcards on one topic from the knowledge base.
+
+    Pipeline:
+      1. Random chunk from FAISS
+      2. Gemini extracts the key topic
+      3. FAISS search by topic (top-5 chunks)
+      4. Gemini generates 3-6 Q&A flashcards
 
     Query params:
-      exclude — comma-separated list of note paths already shown to the user
+      exclude_topics — comma-separated topics already shown to the user
+                       (for deduplication between sessions)
+
+    Returns:
+      {"topic": "...", "cards": [{"question": ..., "answer": ..., "source": ...}, ...], "sources": [...]}
     """
     model = get_model()
-    mcp = get_mcp_client()
-    config = get_config()
+    rag = get_rag_chain()  # raises HTTP 503 if FAISS not loaded
 
-    exclude_list = [p for p in exclude.split(",") if p]
-    card = await generate_flashcard(model, mcp, config, exclude_list)
-    return card
+    exclude_list = [t.strip() for t in exclude_topics.split(",") if t.strip()]
+    try:
+        batch = await generate_flashcard_batch(
+            model=model,
+            retrieval=rag._retrieval,
+            exclude_topics=exclude_list,
+        )
+    except Exception as exc:
+        log.exception("generate_flashcard_batch failed")
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    return batch

--- a/backend/api/routes/health.py
+++ b/backend/api/routes/health.py
@@ -8,3 +8,17 @@ router = APIRouter()
 async def health_check() -> JSONResponse:
     """Liveness probe used by Docker / load balancers."""
     return JSONResponse({"status": "ok"})
+
+
+@router.get("/info")
+async def app_info() -> dict:
+    """
+    Public metadata used by the frontend.
+
+    Returns:
+      vault_name — leaf folder name of the Obsidian vault, used to build
+                   obsidian://open?vault=<vault_name>&file=<note> URIs.
+    """
+    from api.dependencies import get_config
+    config = get_config()
+    return {"vault_name": config.vault_path.name}

--- a/backend/db_script/embeddings.py
+++ b/backend/db_script/embeddings.py
@@ -1,0 +1,58 @@
+import os
+from pathlib import Path
+
+import re
+from dotenv import load_dotenv
+from langchain_text_splitters import MarkdownTextSplitter
+from langchain_core.documents import Document
+
+load_dotenv()
+
+
+
+# Ignore images in markdown
+def clean_markdown_images(text: str) -> str:
+    # 1. Remove ![alt](path)
+    # 2. Remove ![[image.png]]
+    pattern = r'!\[\[.*?\]\]|!\[.*?\]\(.*?\)'
+    return re.sub(pattern, '', text)
+
+
+# Read data from vault
+def build_chunks(vault_path: Path) -> list[Document]:
+    """Read data from vault"""
+    documents: list[Document] = []
+    for file_path in vault_path.rglob("*.md"):
+        if ".obsidian" in file_path.parts:
+            continue
+        
+        note_title = file_path.stem
+
+        # Avoid limit of the length of the path in Windows
+        file_path = str(file_path.absolute())
+        if os.name == 'nt' and not file_path.startswith('\\\\?\\'):
+            file_path = '\\\\?\\' + file_path
+
+        with open(file_path, "r", encoding="utf-8") as f:
+            raw_data = f.read()
+
+        data = clean_markdown_images(raw_data)
+        for chunk in split_text(data):
+            content_with_context = f"Note: {note_title}\nContent: {chunk}"
+            documents.append(
+                Document(
+                    page_content=content_with_context,
+                    metadata={"source": note_title, "path": str(file_path)},
+                )
+            )
+
+    return documents
+
+
+def split_text(text: str, chunk_size: int = 4000, chunk_overlap: int = 100) -> list[str]:
+    splitter = MarkdownTextSplitter(
+        chunk_overlap=chunk_overlap,
+        chunk_size=chunk_size,
+    )
+    chunks = splitter.split_text(text)
+    return chunks

--- a/backend/db_script/vectorization.py
+++ b/backend/db_script/vectorization.py
@@ -1,0 +1,46 @@
+import getpass
+import os
+import sys
+from pathlib import Path
+from uuid import uuid4
+
+# Repo root must be on path when running this file directly (not `python -m ...`).
+_repo_root = Path(__file__).resolve().parents[2]
+if str(_repo_root) not in sys.path:
+    sys.path.insert(0, str(_repo_root))
+
+from langchain_google_genai import GoogleGenerativeAIEmbeddings
+from langchain_community.vectorstores import FAISS
+
+from backend.db_script.embeddings import build_chunks
+
+if not os.getenv("GEMINI_API_KEY"):
+    os.environ["GEMINI_API_KEY"] = getpass.getpass("Enter your Google API key: ")
+
+
+def main():
+    model_embeddings = GoogleGenerativeAIEmbeddings(model="gemini-embedding-2-preview",
+                                                    api_key=os.getenv("GEMINI_API_KEY"),
+                                                    task_type='RETRIEVAL_DOCUMENT')
+    
+    vault_path = os.getenv("VAULT_PATH")
+    if not vault_path:
+        print("Error: Specify VAULT_PATH in .env file")
+        return
+    chunks = build_chunks(Path(vault_path))
+    uuids = [str(uuid4()) for _ in range(len(chunks))]
+
+    print(f"Create database from {len(chunks)} fragments. This may take time...")
+    vector_store = FAISS.from_documents(chunks, model_embeddings, ids=uuids)
+
+    index_path = os.getenv("SAVE_INDEX_PATH")
+    if not index_path:
+        print("Error: Specify SAVE_INDEX_PATH in .env file")
+        return
+    
+    Path(index_path).mkdir(parents=True, exist_ok=True)
+    vector_store.save_local(index_path)
+    print(f"Database saved to {index_path}")
+
+if __name__ == "__main__":
+    main()

--- a/backend/prompts.py
+++ b/backend/prompts.py
@@ -92,6 +92,118 @@ Rules:
 Example output:
 {"question": "What is BM25 and how does it differ from TF-IDF?", "answer": "BM25 is a probabilistic ranking function that scores documents by term frequency and inverse document frequency, with saturation applied to term frequency. Unlike basic TF-IDF, BM25 includes document length normalization and a tunable saturation parameter k1, making it more robust for real-world retrieval."}"""
 
+RAG_SYSTEM_PROMPT = """You are a precise knowledge-base assistant. Your answers must be grounded \
+exclusively in the retrieved context provided to you.
+
+---
+
+## Core Rules
+
+1. **Use only the provided context.** Do not rely on your training data, general knowledge, \
+or assumptions. If the context does not contain enough information to answer, say so explicitly.
+
+2. **Never fabricate.** Do not invent facts, quotes, or references that are not present \
+in the context. Accuracy is more important than sounding helpful.
+
+3. **Cite your sources.** After each claim, reference the note it came from using the format \
+`[Note: <source>]`. If multiple notes support a point, cite all of them.
+
+4. **Acknowledge gaps honestly.** If the retrieved context is insufficient or off-topic, \
+reply with:
+   > "The knowledge base does not contain enough information to answer this question."
+   You may then optionally offer a brief general explanation, clearly labeled \
+   **[General knowledge — not from the knowledge base]**.
+
+5. **Stay focused.** Answer only what was asked. Do not pad the response with background \
+the user did not request.
+
+---
+
+## Response Format
+
+### When the context IS sufficient:
+
+**Answer:** <your answer, based strictly on the context>
+
+**Sources used:**
+- [Note: <source 1>]
+- [Note: <source 2>]
+
+---
+
+### When the context is NOT sufficient:
+
+> The knowledge base does not contain enough information to answer this question.
+
+*(optional)* **[General knowledge — not from the knowledge base]:** <brief explanation>
+
+---
+
+## Retrieved context
+
+The context below was retrieved automatically via semantic search. It may contain \
+multiple fragments from different notes. Treat each fragment as a direct excerpt \
+from the user's knowledge base.
+
+{context}
+"""
+
+RAG_FLASHCARD_PROMPT = """You are a flashcard generator for technical interview preparation.
+
+You will be given a single text fragment extracted from a personal knowledge base.
+The fragment may be a partial section of a larger note — treat it as-is.
+
+Your task: produce exactly ONE flashcard as a JSON object with these fields:
+  - "question": a specific, interview-style question answerable from this fragment alone
+  - "answer": a concise but complete answer (2-5 sentences), drawn only from the fragment
+
+Output rules:
+- Output ONLY valid JSON — no markdown fences, no preamble, no explanation
+- The question must test understanding, not memorization of a single word
+- Prefer "how", "why", "explain", "what is the difference between" question patterns
+- If the fragment is too short or lacks meaningful content, still produce the best card possible
+
+Example output:
+{"question": "Why does BM25 use a saturation function for term frequency?", "answer": "BM25 applies a saturation function to term frequency to prevent a single very frequent term from dominating the score. Beyond a certain count the marginal contribution of each additional occurrence decreases, which better models real-world relevance. This makes BM25 more robust than raw TF-IDF for long documents."}"""
+
+RAG_TOPIC_EXTRACTION_PROMPT = """You are a topic extraction assistant.
+
+You will be given a text fragment from a personal knowledge base.
+Your task: identify the single most important concept or topic discussed in this fragment.
+
+Output rules:
+- Output ONLY the topic as a short phrase (3-10 words)
+- No punctuation at the end, no quotes, no explanation
+- The topic should work as a search query to find related notes
+
+Example outputs:
+BM25 term frequency saturation parameter
+gradient descent learning rate schedules
+Docker multi-stage build optimization"""
+
+RAG_BATCH_FLASHCARD_PROMPT = """You are a flashcard generator for technical interview preparation.
+
+You will be given several text fragments from a personal knowledge base, all related to the same topic.
+Your task: generate between 3 and 6 flashcards as a JSON array.
+
+Each flashcard must be an object with:
+  - "question": a specific, interview-style question answerable from the provided fragments
+  - "answer": a concise but complete answer (2-5 sentences), drawn only from the fragments
+  - "source": the note name from [Note: <name>] tag closest to the relevant content
+
+Output rules:
+- Output ONLY a valid JSON array — no markdown fences, no preamble, no explanation
+- Questions must test understanding, not memorization of a single word
+- Prefer "how", "why", "explain", "what is the difference between" question patterns
+- Each question must be distinct — do not repeat the same concept
+- Vary difficulty: include both conceptual and practical questions
+
+Example output:
+[
+  {"question": "Why does BM25 use a saturation function for term frequency?", "answer": "BM25 applies saturation to prevent a single very frequent term from dominating the relevance score. Beyond a certain count, each additional occurrence contributes less, which better models real-world relevance and makes BM25 more robust than raw TF-IDF.", "source": "BM25 Algorithm"},
+  {"question": "How does document length normalization work in BM25?", "answer": "BM25 divides the term frequency by a factor that grows with document length relative to the average length. This penalizes long documents that contain a term simply because they are long, using a tunable parameter b (typically 0.75).", "source": "BM25 Algorithm"}
+]"""
+
 TOOL_POLICY = """
 You have access to an MCP server connected to the user's Obsidian vault.
 

--- a/backend/retrieval/search.py
+++ b/backend/retrieval/search.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+from dotenv import load_dotenv
+from langchain_community.vectorstores import FAISS
+from langchain_google_genai import GoogleGenerativeAIEmbeddings
+
+load_dotenv()
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+@dataclass
+class SearchResult:
+    """A single text fragment found in the database."""
+    content: str    # chunk text (with the note title)
+    source: str     # note name (from metadata["source"])
+    score: float    # relevance 0..1, higher is better
+
+
+# ---------------------------------------------------------------------------
+# Database loading
+# ---------------------------------------------------------------------------
+
+def load_faiss() -> FAISS:
+    """
+    Loads the FAISS index from disk.
+    The path is taken from the SAVE_INDEX_PATH environment variable.
+    """
+    index_path = os.getenv("SAVE_INDEX_PATH")
+    if not index_path:
+        raise EnvironmentError("Set SAVE_INDEX_PATH in the .env file")
+
+    print("Loading FAISS index...")
+
+    embeddings = GoogleGenerativeAIEmbeddings(
+        model="gemini-embedding-2-preview",
+        task_type="RETRIEVAL_QUERY",      # correct task_type for queries
+    )
+
+    vector_store = FAISS.load_local(
+        index_path,
+        embeddings,
+        allow_dangerous_deserialization=True,
+    )
+
+    print("FAISS index loaded.")
+    return vector_store
+
+
+# ---------------------------------------------------------------------------
+# Search function (Task 2.2)
+# ---------------------------------------------------------------------------
+
+def search(query: str, vector_store: FAISS, top_k: int = 3) -> list[SearchResult]:
+    """
+    Accepts a query string, converts it to a vector and returns
+    the top_k most similar fragments from the database.
+
+    Parameters
+    ----------
+    query        : question or key phrase to search for
+    vector_store : loaded FAISS index (result of load_faiss())
+    top_k        : how many results to return (default 3)
+
+    Returns
+    ----------
+    List of SearchResult sorted from most to least relevant.
+    Score is normalised to the range [0, 1]; 1.0 is a perfect match.
+    """
+    if not query.strip():
+        return []
+
+    # similarity_search_with_relevance_scores returns [(Document, float), ...]
+    # float — cosine similarity normalised to [0, 1]
+    docs_and_scores = vector_store.similarity_search_with_relevance_scores(
+        query, k=top_k
+    )
+
+    results: list[SearchResult] = []
+    for doc, score in docs_and_scores:
+        results.append(
+            SearchResult(
+                content=doc.page_content,
+                source=doc.metadata.get("source", "unknown note"),
+                score=round(score, 4),
+            )
+        )
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# RetrievalService — a convenient wrapper for use in the API
+# ---------------------------------------------------------------------------
+
+class RetrievalService:
+    """
+    Encapsulates the FAISS index and the search method.
+    Created once at application startup (in lifespan).
+
+    Example usage:
+        retrieval = RetrievalService()
+        results = retrieval.search("What is BM25?")
+        for r in results:
+            print(r.score, r.source, r.content[:80])
+    """
+
+    def __init__(self) -> None:
+        self._store: FAISS = load_faiss()
+
+    def search(self, query: str, top_k: int = 3) -> list[SearchResult]:
+        """
+        Find the top_k most similar fragments by query string.
+
+        RAG hook: this method will be called from services/orchestrator.py
+        to pass context to the model before answering the user.
+        """
+        return search(query, self._store, top_k=top_k)

--- a/backend/services/orchestrator.py
+++ b/backend/services/orchestrator.py
@@ -85,7 +85,7 @@ class Orchestrator:
                     yield {"type": "done", "content": text}
                     return
 
-            yield {"type": "done", "content": "[Ошибка: превышено максимальное количество шагов]"}
+            yield {"type": "done", "content": "[Error: maximum number of steps exceeded]"}
 
         except Exception as exc:
             yield {"type": "error", "content": str(exc)}
@@ -129,65 +129,10 @@ class Orchestrator:
                 self._messages.append({"role": "assistant", "content": text})
                 return text
 
-        return "[Ошибка: превышено максимальное количество шагов без финального ответа]"
+        return "[Error: maximum number of steps exceeded without a final answer]"
 
     async def _ensure_tools(self) -> list[dict]:
         if self._tools is None:
             self._tools = await self._mcp.list_tools()
         return self._tools
 
-
-# ------------------------------------------------------------------
-# Flashcard generation (standalone — does not touch chat history)
-# ------------------------------------------------------------------
-
-async def generate_flashcard(
-    model: BaseModel,
-    mcp_client: MCPClient,
-    config: Config,
-    exclude: list[str] | None = None,
-) -> dict:
-    """
-    Pick a random vault note and generate a Q&A flashcard via the model.
-
-    Returns: {"question": "...", "answer": "...", "source": "path"}
-
-    RAG hook: in the future, replace the random note selection with a
-    retrieval step from services.retrieval.RetrievalService.
-    """
-    import random
-
-    from prompts import FLASHCARD_PROMPT
-
-    notes_raw = await mcp_client.call_tool("list_notes", {})
-    notes: list[dict] = (
-        json.loads(notes_raw) if isinstance(notes_raw, str) else notes_raw
-    )
-
-    candidates = [n for n in notes if n["path"] not in (exclude or [])]
-    if not candidates:
-        candidates = notes  # all seen → reset cycle
-
-    note = random.choice(candidates)
-    content_raw = await mcp_client.call_tool("read_note", {"path": note["path"]})
-    content_obj: dict = (
-        json.loads(content_raw) if isinstance(content_raw, str) else content_raw
-    )
-    note_text = content_obj.get("content", "")
-
-    messages = [
-        {"role": "system", "content": FLASHCARD_PROMPT},
-        {"role": "user", "content": f"Note title: {note['title']}\n\n{note_text}"},
-    ]
-    response = await model.chat(messages, tools=[])
-    raw_text = response.text.strip()
-
-    if raw_text.startswith("```"):
-        raw_text = raw_text.split("```")[1]
-        if raw_text.startswith("json"):
-            raw_text = raw_text[4:]
-        raw_text = raw_text.strip()
-
-    card: dict = json.loads(raw_text)
-    card["source"] = note["path"]
-    return card

--- a/backend/services/rag.py
+++ b/backend/services/rag.py
@@ -1,0 +1,290 @@
+"""
+RAG chain — Tasks 3.2 and 3.3.
+
+Contains two independent components:
+
+  RagChain.ask()              — Task 3.2
+    question → FAISS search → RAG_SYSTEM_PROMPT → Gemini → coherent answer
+
+  generate_rag_flashcard()    — Task 3.3
+    random chunk from FAISS → RAG_FLASHCARD_PROMPT → Gemini → JSON {question, answer}
+
+Both components do NOT touch the MCP chain (orchestrator.py).
+"""
+from __future__ import annotations
+
+import json
+import random
+
+from langchain_community.vectorstores import FAISS
+
+from model.base import BaseModel
+from prompts import (
+    RAG_BATCH_FLASHCARD_PROMPT,
+    RAG_FLASHCARD_PROMPT,
+    RAG_SYSTEM_PROMPT,
+    RAG_TOPIC_EXTRACTION_PROMPT,
+)
+from retrieval.search import RetrievalService, SearchResult
+
+
+class RagChain:
+    """
+    Chain: question → FAISS → prompt → Gemini → answer.
+
+    Created once at application startup:
+
+        rag = RagChain(model=gemini_model)
+
+    Then called for each question:
+
+        answer = await rag.ask("What is BM25?")
+    """
+
+    def __init__(self, model: BaseModel) -> None:
+        self._model = model
+        self._retrieval = RetrievalService()   # loads FAISS once
+
+    # ------------------------------------------------------------------
+    # Public method
+    # ------------------------------------------------------------------
+
+    async def ask(self, question: str, top_k: int = 3) -> RagAnswer:
+        """
+        Accept a question, find relevant chunks, get an answer from the model.
+
+        Parameters
+        ----------
+        question : user question
+        top_k    : how many chunks to pass into context (default 3)
+
+        Returns
+        ----------
+        RagAnswer with the answer text and list of sources used.
+        """
+        # ── Step 1: semantic search via FAISS ─────────────────────────
+        chunks: list[SearchResult] = self._retrieval.search(question, top_k=top_k)
+
+        # ── Step 2: build the context text block ──────────────────────
+        if chunks:
+            context_block = _format_context(chunks)
+        else:
+            context_block = "No relevant fragments found in the knowledge base."
+
+        # ── Step 3: inject context into the system prompt ─────────────
+        system_prompt = RAG_SYSTEM_PROMPT.format(context=context_block)
+
+        # ── Step 4: call the model (without MCP tools) ────────────────
+        messages = [
+            {"role": "system", "content": system_prompt},
+            {"role": "user",   "content": question},
+        ]
+        response = await self._model.chat(messages, tools=[])
+
+        return RagAnswer(
+            answer=response.text.strip(),
+            sources=[c.source for c in chunks],
+            chunks=chunks,
+        )
+
+
+# ------------------------------------------------------------------
+# Helper types and functions
+# ------------------------------------------------------------------
+
+class RagAnswer:
+    """Result of a single RAG call."""
+
+    __slots__ = ("answer", "sources", "chunks")
+
+    def __init__(
+        self,
+        answer: str,
+        sources: list[str],
+        chunks: list[SearchResult],
+    ) -> None:
+        self.answer = answer
+        self.sources = sources    # unique note names
+        self.chunks = chunks      # full objects for debugging
+
+    def __repr__(self) -> str:
+        return f"RagAnswer(sources={self.sources!r}, answer={self.answer[:60]!r}…)"
+
+
+# ------------------------------------------------------------------
+# Flashcard generator from FAISS — Task 3.3
+# ------------------------------------------------------------------
+
+async def generate_rag_flashcard(
+    model: BaseModel,
+    retrieval: RetrievalService,
+    exclude: list[str] | None = None,
+) -> dict:
+    """
+    Take a random chunk from FAISS and ask Gemini to generate a flashcard.
+
+    Difference from the old generate_flashcard() in orchestrator.py:
+      - Old: a random full NOTE via MCP (list_notes → read_note)
+      - This: a random CHUNK from FAISS (already split, ≤4000 characters)
+
+    Parameters
+    ----------
+    model      : model (Gemini / Ollama)
+    retrieval  : already loaded RetrievalService (FAISS in memory)
+    exclude    : list of source names for already-shown flashcards (deduplication)
+
+    Returns
+    ----------
+    {"question": "...", "answer": "...", "source": "<note name>"}
+    """
+    # ── Step 1: get all chunks from the FAISS index ───────────────────
+    # LangChain stores documents in vector_store.docstore._dict: {id: Document}
+    all_docs = list(retrieval._store.docstore._dict.values())
+
+    if not all_docs:
+        raise ValueError("FAISS index is empty — run vectorization.py first")
+
+    # ── Step 2: exclude already-shown sources ─────────────────────────
+    seen = set(exclude or [])
+    candidates = [d for d in all_docs if d.metadata.get("source") not in seen]
+    if not candidates:
+        candidates = all_docs   # all shown → start over
+
+    chunk = random.choice(candidates)
+    source = chunk.metadata.get("source", "unknown")
+
+    # ── Step 3: call the model with RAG_FLASHCARD_PROMPT ──────────────
+    messages = [
+        {"role": "system", "content": RAG_FLASHCARD_PROMPT},
+        {"role": "user",   "content": chunk.page_content},
+    ]
+    response = await model.chat(messages, tools=[])
+    raw_text = response.text.strip()
+
+    # ── Step 4: parse JSON (strip markdown wrapper if model added one)
+    if raw_text.startswith("```"):
+        raw_text = raw_text.split("```")[1]
+        if raw_text.startswith("json"):
+            raw_text = raw_text[4:]
+        raw_text = raw_text.strip()
+
+    card: dict = json.loads(raw_text)
+    card["source"] = source
+    return card
+
+
+# ------------------------------------------------------------------
+# Flashcard batch generator — new pipeline
+# ------------------------------------------------------------------
+
+async def generate_flashcard_batch(
+    model: BaseModel,
+    retrieval: RetrievalService,
+    exclude_topics: list[str] | None = None,
+    top_k: int = 5,
+    min_cards: int = 3,
+    max_cards: int = 6,
+) -> dict:
+    """
+    Generates a batch of 3-6 flashcards on one topic:
+
+    1. Takes a random chunk from FAISS
+    2. Asks Gemini to extract the key topic (a short search query)
+    3. Searches FAISS for top_k chunks on that topic
+    4. Asks Gemini to generate 3-6 flashcards from the found fragments
+    5. Returns {"topic": "...", "cards": [...], "sources": [...]}
+
+    Parameters
+    ----------
+    model          : language model
+    retrieval      : loaded RetrievalService
+    exclude_topics : list of topics already shown to the user (deduplication)
+    top_k          : how many similar chunks to search by topic (default 5)
+    min_cards      : minimum number of flashcards (passed to the prompt)
+    max_cards      : maximum number of flashcards (passed to the prompt)
+    """
+    # ── Step 1: random chunk from FAISS ───────────────────────────────
+    all_docs = list(retrieval._store.docstore._dict.values())
+    if not all_docs:
+        raise ValueError("FAISS index is empty — run vectorization.py first")
+
+    seen = set(exclude_topics or [])
+    # Try to find a chunk from a not-yet-exhausted source
+    candidates = [d for d in all_docs if d.metadata.get("source") not in seen]
+    if not candidates:
+        candidates = all_docs  # all topics shown → reset cycle
+
+    seed_doc = random.choice(candidates)
+
+    # ── Step 2: extract the key topic ─────────────────────────────────
+    topic_messages = [
+        {"role": "system", "content": RAG_TOPIC_EXTRACTION_PROMPT},
+        {"role": "user",   "content": seed_doc.page_content},
+    ]
+    topic_response = await model.chat(topic_messages, tools=[])
+    topic = topic_response.text.strip().strip("\"'")
+
+    # ── Step 3: search for similar chunks by topic ────────────────────
+    chunks: list[SearchResult] = retrieval.search(topic, top_k=top_k)
+
+    if not chunks:
+        # Fallback: if search found nothing, use the seed document
+        chunks = [
+            SearchResult(
+                content=seed_doc.page_content,
+                source=seed_doc.metadata.get("source", "unknown"),
+                score=1.0,
+            )
+        ]
+
+    context_block = _format_context(chunks)
+
+    # ── Step 4: generate the flashcard batch ──────────────────────────
+    cards_messages = [
+        {"role": "system", "content": RAG_BATCH_FLASHCARD_PROMPT},
+        {
+            "role": "user",
+            "content": (
+                f"Topic: {topic}\n\n"
+                f"Generate {min_cards} to {max_cards} flashcards "
+                f"based on the following fragments:\n\n{context_block}"
+            ),
+        },
+    ]
+    cards_response = await model.chat(cards_messages, tools=[])
+    raw_text = cards_response.text.strip()
+
+    # Strip markdown wrapper if the model added one anyway
+    if raw_text.startswith("```"):
+        raw_text = raw_text.split("```")[1]
+        if raw_text.startswith("json"):
+            raw_text = raw_text[4:]
+        raw_text = raw_text.strip()
+
+    cards: list[dict] = json.loads(raw_text)
+
+    return {
+        "topic": topic,
+        "cards": cards,
+        "sources": list({c.source for c in chunks}),
+    }
+
+
+# ------------------------------------------------------------------
+# Helper functions
+# ------------------------------------------------------------------
+
+def _format_context(chunks: list[SearchResult]) -> str:
+    """
+    Convert a list of SearchResult into a text block for the prompt.
+
+    Format of each fragment:
+        [Note: <name>] (relevance: 0.87)
+        <chunk text>
+    """
+    parts: list[str] = []
+    for i, chunk in enumerate(chunks, start=1):
+        parts.append(
+            f"[Note: {chunk.source}] (relevance: {chunk.score})\n{chunk.content}"
+        )
+    return "\n\n---\n\n".join(parts)

--- a/environment.yml
+++ b/environment.yml
@@ -14,3 +14,8 @@ dependencies:
       - pydantic>=2.0.0
       - fastapi>=0.100.0
       - uvicorn[standard]>=0.20.0
+      - langchain
+      - langchain-community
+      - langchain-text-splitters
+      - langchain-google-genai
+      - faiss-cpu

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -11,9 +11,9 @@ server {
         try_files $uri $uri/ /index.html;
     }
 
-    # ── Backend API proxy ──────────────────────────────────────────────────
-    # All REST calls from the browser go through nginx to avoid CORS issues.
+    # ── Backend REST proxies ───────────────────────────────────────────────
 
+    # /flashcard/batch and legacy /flashcard — prefix match covers both
     location /flashcard {
         proxy_pass         http://backend:8000;
         proxy_set_header   Host $host;
@@ -27,14 +27,32 @@ server {
         proxy_set_header Host $host;
     }
 
-    # ── WebSocket proxy ────────────────────────────────────────────────────
+    location /info {
+        proxy_pass       http://backend:8000;
+        proxy_set_header Host $host;
+    }
+
+    # ── WebSocket proxies ──────────────────────────────────────────────────
+
+    # MCP chat — model calls Obsidian tools
     location /ws {
         proxy_pass             http://backend:8000;
         proxy_http_version     1.1;
         proxy_set_header       Upgrade $http_upgrade;
         proxy_set_header       Connection "upgrade";
         proxy_set_header       Host $host;
-        proxy_read_timeout     3600s;  # keep WebSocket alive for long sessions
+        proxy_read_timeout     3600s;
+        proxy_send_timeout     3600s;
+    }
+
+    # RAG chat — FAISS semantic search
+    location /ask {
+        proxy_pass             http://backend:8000;
+        proxy_http_version     1.1;
+        proxy_set_header       Upgrade $http_upgrade;
+        proxy_set_header       Connection "upgrade";
+        proxy_set_header       Host $host;
+        proxy_read_timeout     3600s;
         proxy_send_timeout     3600s;
     }
 

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -21,6 +21,8 @@
     --tool-txt: #74c7ec;
     --err-bg:   #3c1f24;
     --err-txt:  #f38ba8;
+    --src-bg:   #1e2d1e;
+    --src-txt:  #a6e3a1;
     --radius:   12px;
     --font:     'Segoe UI', system-ui, sans-serif;
   }
@@ -36,13 +38,14 @@
 
   /* ── Шапка ── */
   header {
-    padding: 14px 20px;
+    padding: 12px 20px;
     background: var(--surface);
     border-bottom: 1px solid var(--border);
     display: flex;
     align-items: center;
     gap: 10px;
     flex-shrink: 0;
+    flex-wrap: wrap;
   }
   header h1 { font-size: 1rem; font-weight: 600; color: var(--accent); }
   header span { font-size: .8rem; color: var(--muted); }
@@ -52,9 +55,15 @@
   }
   .dot.offline { background: var(--muted); }
 
-  /* ── Переключатель режима ── */
-  .mode-toggle {
+  /* ── Переключатели ── */
+  .toggle-group {
     margin-left: auto;
+    display: flex;
+    gap: 8px;
+    align-items: center;
+  }
+
+  .toggle {
     display: flex;
     gap: 4px;
     background: var(--bg);
@@ -62,7 +71,7 @@
     border-radius: 8px;
     padding: 3px;
   }
-  .mode-btn {
+  .toggle-btn {
     background: none;
     border: none;
     border-radius: 6px;
@@ -73,9 +82,18 @@
     padding: 4px 14px;
     transition: background .15s, color .15s;
   }
-  .mode-btn.active {
+  .toggle-btn.active {
     background: var(--surface);
     color: var(--accent);
+  }
+
+  /* Маленький переключатель MCP / RAG */
+  #chat-sub-toggle {
+    font-size: .75rem;
+  }
+  #chat-sub-toggle .toggle-btn {
+    font-size: .75rem;
+    padding: 3px 10px;
   }
 
   /* ── Область чата ── */
@@ -148,6 +166,30 @@
     color: var(--muted);
     margin: .3em 0;
   }
+
+  /* ── Источники под ответом ── */
+  .sources {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-top: 6px;
+    padding-left: 2px;
+  }
+  .source-tag {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: .74rem;
+    color: var(--src-txt);
+    background: var(--src-bg);
+    border: 1px solid var(--src-txt);
+    padding: 2px 9px;
+    border-radius: 20px;
+    text-decoration: none;
+    transition: opacity .15s;
+    cursor: pointer;
+  }
+  .source-tag:hover { opacity: .8; }
 
   /* ── Индикаторы инструментов ── */
   .tool-chip {
@@ -240,17 +282,43 @@
   #send:hover  { opacity: .85; }
   #send:disabled { opacity: .4; cursor: default; }
 
-  /* ── Карточки ── */
+  /* ── Панель карточек ── */
   #flashcard-panel {
     display: none;
     flex-direction: column;
     align-items: center;
     justify-content: center;
     flex: 1;
-    padding: 24px 16px;
-    gap: 20px;
+    padding: 20px 16px;
+    gap: 16px;
   }
 
+  /* Тема и прогресс */
+  .fc-header {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
+  }
+  .fc-topic {
+    font-size: .82rem;
+    color: var(--accent);
+    background: var(--tool-bg);
+    border: 1px solid var(--tool-txt);
+    padding: 3px 14px;
+    border-radius: 20px;
+    max-width: 90vw;
+    text-align: center;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .fc-progress {
+    font-size: .73rem;
+    color: var(--muted);
+  }
+
+  /* Карточка с 3D-переворотом */
   .fc-card {
     perspective: 1000px;
     width: 620px;
@@ -301,7 +369,17 @@
     flex-direction: column;
     gap: 12px;
   }
-  .fc-source { font-size: .7rem; color: var(--muted); }
+  .fc-source-link {
+    font-size: .73rem;
+    color: var(--src-txt);
+    background: var(--src-bg);
+    border: 1px solid var(--src-txt);
+    padding: 2px 10px;
+    border-radius: 20px;
+    text-decoration: none;
+    transition: opacity .15s;
+  }
+  .fc-source-link:hover { opacity: .8; }
 
   .fc-controls {
     display: flex;
@@ -331,15 +409,28 @@
   <div class="dot" id="dot"></div>
   <h1>Obsidian MCP Чат</h1>
   <span>Ваши заметки — главный источник истины</span>
-  <div class="mode-toggle">
-    <button class="mode-btn active" id="btn-chat" onclick="setMode('chat')">Чат</button>
-    <button class="mode-btn" id="btn-flash" onclick="setMode('flashcards')">Карточки</button>
+  <div class="toggle-group">
+    <!-- Переключатель MCP / RAG (только в режиме чата) -->
+    <div class="toggle" id="chat-sub-toggle">
+      <button class="toggle-btn active" id="btn-mcp" onclick="setChatMode('mcp')" title="Чат через MCP-инструменты">MCP</button>
+      <button class="toggle-btn"        id="btn-rag" onclick="setChatMode('rag')" title="Чат через FAISS-поиск">RAG</button>
+    </div>
+    <!-- Переключатель Чат / Карточки -->
+    <div class="toggle">
+      <button class="toggle-btn active" id="btn-chat"  onclick="setMode('chat')">Чат</button>
+      <button class="toggle-btn"        id="btn-flash" onclick="setMode('flashcards')">Карточки</button>
+    </div>
   </div>
 </header>
 
 <div id="chat"></div>
 
 <div id="flashcard-panel">
+  <div class="fc-header">
+    <div class="fc-topic" id="fc-topic">Загрузка темы…</div>
+    <div class="fc-progress" id="fc-progress"></div>
+  </div>
+
   <div id="fc-card" class="fc-card" onclick="flipCard()" title="Нажмите, чтобы перевернуть">
     <div class="fc-inner">
       <div class="fc-front">
@@ -348,13 +439,14 @@
       </div>
       <div class="fc-back">
         <p id="fc-answer"></p>
-        <p class="fc-source" id="fc-source"></p>
+        <a id="fc-source-link" class="fc-source-link" href="#" target="_blank" style="display:none"></a>
       </div>
     </div>
   </div>
+
   <div class="fc-controls">
     <button id="fc-next" onclick="nextCard()">Следующая карточка →</button>
-    <p class="fc-hint">Нажмите на карточку или Space, чтобы перевернуть · → или N — следующая</p>
+    <p class="fc-hint">Нажмите на карточку или Space — перевернуть · → или N — следующая</p>
   </div>
 </div>
 
@@ -378,42 +470,110 @@
   let thinking = null;
   let busy = false;
 
-  // ── Переключение режима ────────────────────────────────────────────────
-  let mode = 'chat';
-  let seenPaths = [];
-  let cardFlipped = false;
+  // ── Имя хранилища Obsidian (для ссылок obsidian://) ───────────────────
+  let vaultName = '';
+  fetch('/info').then(r => r.json()).then(d => { vaultName = d.vault_name || ''; }).catch(() => {});
+
+  // ── Режим (chat / flashcards) и подрежим чата (mcp / rag) ────────────
+  let mode     = 'chat';
+  let chatMode = 'mcp';  // 'mcp' | 'rag'
 
   function setMode(m) {
     mode = m;
-    chat.style.display = m === 'chat' ? 'flex' : 'none';
-    document.getElementById('input-row').style.display = m === 'chat' ? 'flex' : 'none';
+    chat.style.display              = m === 'chat'       ? 'flex'   : 'none';
+    document.getElementById('input-row').style.display   = m === 'chat'       ? 'flex'   : 'none';
     document.getElementById('flashcard-panel').style.display = m === 'flashcards' ? 'flex' : 'none';
+    document.getElementById('chat-sub-toggle').style.display = m === 'chat'    ? 'flex'   : 'none';
     document.getElementById('btn-chat').classList.toggle('active', m === 'chat');
     document.getElementById('btn-flash').classList.toggle('active', m === 'flashcards');
-    if (m === 'flashcards' && seenPaths.length === 0) nextCard();
+    if (m === 'flashcards' && currentBatch.length === 0) fetchBatch();
   }
 
-  async function nextCard() {
-    cardFlipped = false;
-    document.getElementById('fc-card').classList.remove('flipped');
-    document.getElementById('fc-question').textContent = 'Генерация…';
-    document.getElementById('fc-answer').textContent   = '';
-    document.getElementById('fc-source').textContent   = '';
+  function setChatMode(m) {
+    chatMode = m;
+    document.getElementById('btn-mcp').classList.toggle('active', m === 'mcp');
+    document.getElementById('btn-rag').classList.toggle('active', m === 'rag');
+    // Переподключиться к другому WebSocket-эндпоинту
+    if (ws) { ws.onclose = null; ws.close(); ws = null; }
+    connect();
+  }
+
+  // ── Карточки: батчевый цикл ───────────────────────────────────────────
+  let currentBatch  = [];   // [{question, answer, source}, ...]
+  let batchIndex    = 0;
+  let cardFlipped   = false;
+  let seenTopics    = [];   // темы уже показанных батчей
+
+  async function fetchBatch() {
     document.getElementById('fc-next').disabled = true;
+    document.getElementById('fc-question').textContent = 'Генерация темы…';
+    document.getElementById('fc-answer').textContent   = '';
+    document.getElementById('fc-topic').textContent    = 'Загрузка…';
+    document.getElementById('fc-progress').textContent = '';
+    hideSourceLink();
 
     try {
-      const exclude = seenPaths.join(',');
-      const res  = await fetch(`/flashcard?exclude=${encodeURIComponent(exclude)}`);
+      const exclude = seenTopics.join(',');
+      const res = await fetch(`/flashcard/batch?exclude_topics=${encodeURIComponent(exclude)}`);
       if (!res.ok) throw new Error(`Ошибка сервера ${res.status}`);
-      const card = await res.json();
-      document.getElementById('fc-question').textContent = card.question || '(нет вопроса)';
-      document.getElementById('fc-answer').textContent   = card.answer   || '(нет ответа)';
-      document.getElementById('fc-source').textContent   = card.source ? `📄 ${card.source}` : '';
-      if (card.source) seenPaths.push(card.source);
+      const data = await res.json();
+
+      currentBatch = data.cards || [];
+      batchIndex   = 0;
+
+      if (currentBatch.length === 0) throw new Error('Сервер вернул пустой батч');
+
+      seenTopics.push(data.topic);
+      document.getElementById('fc-topic').textContent = `🎯 ${data.topic}`;
+      showCard(0);
     } catch (err) {
       document.getElementById('fc-question').textContent = `Ошибка: ${err.message}`;
+      document.getElementById('fc-topic').textContent = '—';
     } finally {
       document.getElementById('fc-next').disabled = false;
+    }
+  }
+
+  function showCard(index) {
+    cardFlipped = false;
+    document.getElementById('fc-card').classList.remove('flipped');
+
+    const card = currentBatch[index];
+    document.getElementById('fc-question').textContent = card.question || '(нет вопроса)';
+    document.getElementById('fc-answer').textContent   = card.answer   || '(нет ответа)';
+    document.getElementById('fc-progress').textContent =
+      `${index + 1} / ${currentBatch.length}`;
+
+    const src = card.source || '';
+    if (src && vaultName) {
+      showSourceLink(`obsidian://open?vault=${encodeURIComponent(vaultName)}&file=${encodeURIComponent(src)}`, `📄 ${src}`);
+    } else if (src) {
+      showSourceLink('#', `📄 ${src}`);
+    } else {
+      hideSourceLink();
+    }
+  }
+
+  function showSourceLink(href, label) {
+    const el = document.getElementById('fc-source-link');
+    el.href        = href;
+    el.textContent = label;
+    el.style.display = 'inline-flex';
+  }
+  function hideSourceLink() {
+    document.getElementById('fc-source-link').style.display = 'none';
+  }
+
+  function nextCard() {
+    if (currentBatch.length === 0) { fetchBatch(); return; }
+    batchIndex++;
+    if (batchIndex < currentBatch.length) {
+      showCard(batchIndex);
+    } else {
+      // Батч исчерпан — загружаем следующую тему
+      currentBatch = [];
+      batchIndex   = 0;
+      fetchBatch();
     }
   }
 
@@ -424,15 +584,21 @@
 
   document.addEventListener('keydown', (e) => {
     if (mode === 'flashcards') {
-      if (e.key === ' ' || e.key === 'Enter') { e.preventDefault(); flipCard(); }
-      if (e.key === 'ArrowRight' || e.key === 'n') nextCard();
+      if (e.key === ' ')                            { e.preventDefault(); flipCard(); }
+      if (e.key === 'ArrowRight' || e.key === 'n')  { e.preventDefault(); nextCard(); }
     }
   });
 
   // ── WebSocket ──────────────────────────────────────────────────────────
-  function connect() {
+  function wsEndpoint() {
     const proto = location.protocol === 'https:' ? 'wss' : 'ws';
-    ws = new WebSocket(`${proto}://${location.host}/ws`);
+    return chatMode === 'rag'
+      ? `${proto}://${location.host}/ask`
+      : `${proto}://${location.host}/ws`;
+  }
+
+  function connect() {
+    ws = new WebSocket(wsEndpoint());
 
     ws.onopen  = () => dot.classList.remove('offline');
     ws.onclose = () => {
@@ -445,6 +611,7 @@
       const ev = JSON.parse(e.data);
 
       if (ev.type === 'tool_start') {
+        // Только в MCP-режиме
         removeThinking();
         if (!toolsEl) {
           toolsEl = document.createElement('div');
@@ -465,7 +632,7 @@
       } else if (ev.type === 'done') {
         removeThinking();
         toolsEl = null;
-        appendBot(ev.content);
+        appendBot(ev.content, ev.sources || []);
         setBusy(false);
 
       } else if (ev.type === 'error') {
@@ -486,10 +653,24 @@
     scrollBottom();
   }
 
-  function appendBot(markdown) {
+  function appendBot(markdown, sources) {
     const el = document.createElement('div');
     el.className = 'msg bot';
-    el.innerHTML = `<div class="bubble">${marked.parse(markdown)}</div>`;
+
+    let html = `<div class="bubble">${marked.parse(markdown)}</div>`;
+
+    // Источники: показываем только если сервер вернул их явно (RAG-режим)
+    if (sources && sources.length > 0) {
+      const tagsHtml = sources.map(src => {
+        const href = (vaultName && src)
+          ? `obsidian://open?vault=${encodeURIComponent(vaultName)}&file=${encodeURIComponent(src)}`
+          : '#';
+        return `<a class="source-tag" href="${escHtml(href)}" title="Открыть в Obsidian">📄 ${escHtml(src)}</a>`;
+      }).join('');
+      html += `<div class="sources">${tagsHtml}</div>`;
+    }
+
+    el.innerHTML = html;
     chat.appendChild(el);
     scrollBottom();
   }
@@ -533,7 +714,9 @@
   }
 
   function escHtml(s) {
-    return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+    return String(s)
+      .replace(/&/g,'&amp;').replace(/</g,'&lt;')
+      .replace(/>/g,'&gt;').replace(/"/g,'&quot;');
   }
 
   function scrollBottom() {

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,8 @@ python-dotenv>=1.0.0
 pydantic>=2.0.0
 fastapi>=0.100.0
 uvicorn[standard]>=0.20.0
+langchain
+langchain-community
+langchain-text-splitters
+langchain-google-genai
+faiss-cpu

--- a/run.py
+++ b/run.py
@@ -2,14 +2,14 @@
 Entry point for the Obsidian MCP Chat system.
 
 Usage:
-    python run.py                                      # Web UI on :7860 (default)
-    python run.py --ui web --port 8080                 # Custom port
-    python run.py --ui cli                             # Terminal chat
-    python run.py --model ollama                       # Local Ollama
+    python run.py                          # Web UI on :7860 (default)
+    python run.py --port 8080              # Custom port
+    python run.py --model ollama           # Local Ollama
+    python run.py --ui cli                 # Terminal chat
     python run.py --model ollama --ollama-model llama3.2:3b
 
 Prerequisites:
-    Gemini:  Set GEMINI_API_KEY in .env  (get key: https://aistudio.google.com)
+    Gemini:  Set GEMINI_API_KEY in .env  (https://aistudio.google.com)
     Ollama:  `ollama serve` running + model pulled
              e.g. `ollama pull qwen2.5:7b-instruct-q4_K_M`
 """
@@ -18,8 +18,13 @@ from __future__ import annotations
 import argparse
 import asyncio
 import sys
+from pathlib import Path
 
-from config import Config
+# ── Add backend/ to sys.path so all backend imports resolve correctly ────────
+BACKEND_DIR = Path(__file__).parent / "backend"
+sys.path.insert(0, str(BACKEND_DIR))
+
+from config import Config  # noqa: E402  (import after sys.path setup)
 
 
 def parse_args() -> argparse.Namespace:
@@ -69,7 +74,7 @@ def build_model(config: Config):
             sys.exit(1)
         return GeminiModel(config)
 
-    elif config.model_backend == "ollama":
+    if config.model_backend == "ollama":
         from model.ollama_model import OllamaModel
         return OllamaModel(config)
 
@@ -78,25 +83,46 @@ def build_model(config: Config):
 
 def run_web(model, config: Config, port: int) -> None:
     import uvicorn
-    import ui.web as web_module
+    from fastapi.responses import FileResponse
+    from api.app import create_app
 
-    # Inject model + config before uvicorn starts accepting requests
-    web_module._model = model
-    web_module._config = config
+    app = create_app(model, config)
+
+    # ── Serve the frontend HTML at / for local development ──────────────
+    # In production, nginx serves frontend/src/index.html directly.
+    # When running `python run.py`, this route handles it instead.
+    frontend_html = Path(__file__).parent / "frontend" / "src" / "index.html"
+
+    @app.get("/")
+    async def serve_frontend():
+        return FileResponse(str(frontend_html))
 
     print(f"Starting Obsidian MCP Chat → http://localhost:{port}")
-    uvicorn.run(web_module.app, host="0.0.0.0", port=port, log_level="warning")
+    uvicorn.run(app, host="0.0.0.0", port=port, log_level="info")
 
 
 async def run_cli(model, config: Config) -> None:
     from client.mcp_client import MCPClient
-    from client.orchestrator import Orchestrator
-    from ui.cli import CLI
+    from services.orchestrator import Orchestrator
+
+    print("\033[1mObsidian MCP Chat (CLI)\033[0m")
+    print("Your notes are the primary source of truth.")
+    print("Type \033[1mquit\033[0m or press Ctrl+C to exit.")
+    print("-" * 50)
 
     async with MCPClient() as mcp_client:
         orchestrator = Orchestrator(model, mcp_client, config)
-        cli = CLI(orchestrator)
-        await cli.run()
+        while True:
+            try:
+                user_input = input("\nYou: ").strip()
+            except (KeyboardInterrupt, EOFError):
+                print("\nGoodbye!")
+                break
+            if not user_input or user_input.lower() in ("quit", "exit", "выход"):
+                print("Goodbye!")
+                break
+            answer = await orchestrator.handle_query(user_input)
+            print(f"\nBot: {answer}")
 
 
 def main() -> None:


### PR DESCRIPTION
- Add FAISS-based semantic search (retrieval/search.py, RetrievalService)
- Add RagChain connecting FAISS search → Gemini for RAG chat (/ask WS)
- Add flashcard batch pipeline: random chunk → topic extraction → FAISS search → 3-6 Q&A cards (/flashcard/batch)
- Add RAG_SYSTEM_PROMPT, RAG_FLASHCARD_PROMPT, RAG_TOPIC_EXTRACTION_PROMPT, RAG_BATCH_FLASHCARD_PROMPT to prompts.py
- Add /info endpoint exposing vault name for obsidian:// deep links
- Add RagChain singleton to lifespan (loaded once, fault-tolerant if FAISS missing)
- Update frontend: MCP/RAG chat toggle, batch flashcard cycling with topic/progress display, source tags with obsidian:// links
- Update nginx: proxy /ask WebSocket and /info REST endpoints
- Fix run.py to use new backend/ structure instead of old ui/web.py
- Translate all Russian comments, docstrings, and print statements to English
- Fix embedding model mismatch: search.py now uses gemini-embedding-2-preview (matches vectorization.py)